### PR TITLE
Replace broken profiling with time

### DIFF
--- a/google2016_unbreakable/win.py
+++ b/google2016_unbreakable/win.py
@@ -61,4 +61,3 @@ def hook(state):
 
 m.should_profile = True
 m.run(procs=10)
-print str(m._executor.dump_stats())

--- a/manticore_challenge/win.py
+++ b/manticore_challenge/win.py
@@ -66,4 +66,3 @@ m.verbosity = 0
 m.workers = 1
 m.should_profile = True
 m.run()
-print str(m._executor.dump_stats())

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -4,7 +4,7 @@ RV=0
 
 # Google 2016 Unbreakable
 cd google2016_unbreakable
-python win.py | tee unbreakable.log
+time python win.py | tee unbreakable.log
 if grep -q "CTF{0The1Quick2Brown3Fox4Jumped5Over6The7Lazy8Fox9}" unbreakable.log
 then
     echo "Google 2016 Unbreakable passed"
@@ -16,7 +16,7 @@ cd ..
 
 # Manticore Challenge
 cd manticore_challenge
-python win.py | tee mcore_challenge.log
+time python win.py | tee mcore_challenge.log
 if grep -q "=MANTICORE==" mcore_challenge.log
 then
     echo "Manticore Challenge passed"


### PR DESCRIPTION
The profiling we'd been doing hasn't worked since https://github.com/trailofbits/manticore/commit/520a9be47d4df0cdb4990c3b4f81318574bde8ed and was incorrect even before that when running manticore with multiple workers, so it should be replaced with `time` until we have more robust benchmarking facilities